### PR TITLE
feat: Add SQLAlchemy ORM setup and initial models

### DIFF
--- a/src/backend/database.py
+++ b/src/backend/database.py
@@ -1,0 +1,33 @@
+from sqlalchemy import create_engine
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import sessionmaker
+
+# SQLALCHEMY_DATABASE_URL = "sqlite:///./sql_app.db" # Example for SQLite
+SQLALCHEMY_DATABASE_URL = "postgresql://user:password@host:port/database" # Example for PostgreSQL
+
+# In a real application, get this URL from environment variables or a config file
+# For example:
+# import os
+# SQLALCHEMY_DATABASE_URL = os.getenv("DATABASE_URL", "postgresql://user:password@localhost/mydatabase")
+
+
+engine = create_engine(
+    SQLALCHEMY_DATABASE_URL
+    # connect_args={"check_same_thread": False} # Needed only for SQLite
+)
+
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+Base = declarative_base()
+
+# Dependency to get DB session in FastAPI routes
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+print(f"Database URL for engine: {SQLALCHEMY_DATABASE_URL}") # For debugging, remove in production
+print("SQLAlchemy engine and SessionLocal configured.")
+print("Ensure your database server is running and the DATABASE_URL is correctly set.")

--- a/src/backend/models/.gitkeep
+++ b/src/backend/models/.gitkeep
@@ -1,0 +1,1 @@
+# Ensures the 'models' directory is tracked by Git.

--- a/src/backend/models/__init__.py
+++ b/src/backend/models/__init__.py
@@ -1,0 +1,22 @@
+# Import Base from database.py to be used by models
+from ..database import Base
+
+# Import all models here to make them easily accessible
+from .product import Product
+from .retailer import Retailer
+# Add other models here as they are created, e.g.:
+# from .sales_historical import SalesHistorical
+# from .simulation import Simulation
+# from .simulation_result import SimulationResult
+
+print("Models package initialized. Imported: Product, Retailer")
+print("Ensure that models correctly inherit from the 'Base' imported from database.py.")
+
+# Optional: __all__ to define what `from .models import *` imports
+__all__ = [
+    "Product",
+    "Retailer",
+    # "SalesHistorical",
+    # "Simulation",
+    # "SimulationResult",
+]

--- a/src/backend/models/product.py
+++ b/src/backend/models/product.py
@@ -1,0 +1,37 @@
+from sqlalchemy import Column, String, Date, DECIMAL, Text,TIMESTAMP, func
+from sqlalchemy.dialects.postgresql import JSONB  # For PostgreSQL specific JSONB
+# from sqlalchemy import JSON # Generic JSON type, use if not PostgreSQL or if JSONB is not essential
+
+# Assuming 'Base' is defined in a central 'database.py' or similar
+from ..database import Base # Adjust this import based on your project structure
+
+class Product(Base):
+    __tablename__ = "products"
+
+    sku_id = Column(String, primary_key=True, index=True, unique=True)
+    product_name = Column(String, nullable=False)
+    brand_name = Column(String, nullable=True)
+    category_name = Column(String, nullable=False, index=True)
+    subcategory_name = Column(String, nullable=True)
+    launch_date = Column(Date, nullable=True)
+    discontinuation_date = Column(Date, nullable=True)
+    price_retail_srp = Column(DECIMAL, nullable=True)
+    price_wholesale = Column(DECIMAL, nullable=True)
+    unit_cost = Column(DECIMAL, nullable=True)
+    package_size = Column(String, nullable=True)
+    product_tier = Column(String, nullable=True, index=True)
+
+    # For key_features_json, using JSONB for PostgreSQL.
+    # For other databases, you might use Text or the generic JSON type.
+    key_features_json = Column(JSONB, nullable=True)
+    # key_features_json = Column(JSON, nullable=True) # Generic JSON
+    # key_features_json = Column(Text, nullable=True) # Fallback to Text if JSON type is not well supported
+
+    created_at = Column(TIMESTAMP, server_default=func.now(), nullable=False)
+    updated_at = Column(TIMESTAMP, server_default=func.now(), onupdate=func.now(), nullable=False)
+
+    # Define relationships later, e.g., with sales_historical
+    # sales = relationship("SalesHistorical", back_populates="product")
+
+    def __repr__(self):
+        return f"<Product(sku_id='{self.sku_id}', name='{self.product_name}')>"

--- a/src/backend/models/retailer.py
+++ b/src/backend/models/retailer.py
@@ -1,0 +1,21 @@
+from sqlalchemy import Column, String, Text, Integer, TIMESTAMP, func
+
+# Assuming 'Base' is defined in a central 'database.py' or similar
+from ..database import Base # Adjust this import based on your project structure
+
+class Retailer(Base):
+    __tablename__ = "retailers"
+
+    retailer_id = Column(String, primary_key=True, index=True, unique=True)
+    retailer_name = Column(String, nullable=False)
+    number_of_stores = Column(Integer, nullable=True)
+    notes = Column(Text, nullable=True)
+
+    created_at = Column(TIMESTAMP, server_default=func.now(), nullable=False)
+    updated_at = Column(TIMESTAMP, server_default=func.now(), onupdate=func.now(), nullable=False)
+
+    # Define relationships later, e.g., with sales_historical
+    # sales = relationship("SalesHistorical", back_populates="retailer")
+
+    def __repr__(self):
+        return f"<Retailer(retailer_id='{self.retailer_id}', name='{self.retailer_name}')>"


### PR DESCRIPTION
- Creates `src/backend/database.py` with SQLAlchemy engine, SessionLocal, and declarative Base. Includes a `get_db` dependency for FastAPI.
- Creates `src/backend/models/__init__.py` to package ORM models.
- Adds initial SQLAlchemy models:
    - `src/backend/models/product.py` for the 'products' table.
    - `src/backend/models/retailer.py` for the 'retailers' table.
- Updates `product.py` and `retailer.py` to use the centralized Base from `database.py`.

This sets up the foundational ORM structure for database interaction.