### PR TITLE
fix: Use DATABASE_URL environment variable for database connection

### DIFF
--- a/src/backend/database.py
+++ b/src/backend/database.py
@@ -1,33 +1,31 @@
+import os
 from sqlalchemy import create_engine
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
 
-# SQLALCHEMY_DATABASE_URL = "sqlite:///./sql_app.db" # Example for SQLite
-SQLALCHEMY_DATABASE_URL = "postgresql://user:password@host:5432/database" # Example for PostgreSQL
+# Default to a local development PostgreSQL instance if DATABASE_URL is not set.
+# Replace 'user', 'password', and 'retail_analytics_dev' as needed for your default local setup.
+DEFAULT_DATABASE_URL = "postgresql://user:password@localhost:5432/retail_analytics_dev"
+SQLALCHEMY_DATABASE_URL = os.getenv("DATABASE_URL", DEFAULT_DATABASE_URL)
 
-# In a real application, get this URL from environment variables or a config file
-# For example:
-# import os
-# SQLALCHEMY_DATABASE_URL = os.getenv("DATABASE_URL", "postgresql://user:password@localhost/mydatabase")
+engine = create_engine(
+    SQLALCHEMY_DATABASE_URL
+    # For PostgreSQL, 'connect_args' is usually not needed unless for specific SSL modes etc.
+    # For SQLite, it was: connect_args={"check_same_thread": False}
+)
 
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
-# engine = create_engine(
-#     SQLALCHEMY_DATABASE_URL
-#     # connect_args={"check_same_thread": False} # Needed only for SQLite
-# )
-
-# SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
-
-Base = declarative_base() # Base can be defined without an engine
+Base = declarative_base()
 
 # Dependency to get DB session in FastAPI routes
-# def get_db():
-#     db = SessionLocal()
-#     try:
-#         yield db
-#     finally:
-#         db.close()
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
 
-# print(f"Database URL for engine: {SQLALCHEMY_DATABASE_URL}") # For debugging, remove in production
-# print("SQLAlchemy engine and SessionLocal configured.")
-# print("Ensure your database server is running and the DATABASE_URL is correctly set.")
+# Optional: Add a function to create all tables (for use in main.py during startup if not using Alembic for everything)
+# def create_db_and_tables():
+#     Base.metadata.create_all(bind=engine)

--- a/src/backend/migrations/env.py
+++ b/src/backend/migrations/env.py
@@ -69,6 +69,13 @@ def run_migrations_online() -> None:
     and associate a connection with the context.
 
     """
+    # Import SQLALCHEMY_DATABASE_URL from your project's database configuration
+    from src.backend.database import SQLALCHEMY_DATABASE_URL
+
+    # Set the sqlalchemy.url in the Alembic config object to be used by engine_from_config
+    # This ensures that the environment variable (via database.py) is the source of truth
+    config.set_main_option('sqlalchemy.url', SQLALCHEMY_DATABASE_URL)
+
     connectable = engine_from_config(
         config.get_section(config.config_ini_section, {}),
         prefix="sqlalchemy.",


### PR DESCRIPTION
- Modifies `src/backend/database.py` to:
    - Read `SQLALCHEMY_DATABASE_URL` from the `DATABASE_URL` environment variable.
    - Provide a default local PostgreSQL URL if `DATABASE_URL` is not set.
    - Reinstate SQLAlchemy `engine` and `SessionLocal` creation using this URL.
    - Reinstate the `get_db` FastAPI dependency.
- Updates `src/backend/migrations/env.py` in `run_migrations_online()` to set `config.set_main_option('sqlalchemy.url', SQLALCHEMY_DATABASE_URL)` from `src.backend.database`. This ensures Alembic's online mode also uses the environment-defined URL as the single source of truth.

This makes the database connection string configurable via the environment, which is crucial for running in different environments (dev, staging, prod) and for applying Alembic migrations correctly.